### PR TITLE
New version of SBML4j

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,17 +87,11 @@ services:
             - "7687"
         environment:
             - NEO4J_CONF=/vol/conf
-            - NEO4J_dbms_security_auth__enabled=false
-            - NEO4J_dbms_memory_pagecache_size=1G
-            - NEO4J_dbms_memory_heap_initial__size=2G
-            - NEO4J_dbms_memory_heap_max__size=2G
-            - NEO4J_dbms_security_procedures_unrestricted=apoc.algo.dijkstraWithDefaultWeight, apoc.path.expand
-            - NEO4J_dbms_security_procedures_whitelist=apoc.algo.dijkstraWithDefaultWeight, apoc.path.expand
         restart: unless-stopped
         command: ["neo4j"]
  
     sbml4j:
-        image: pecax/sbml4j:1.0
+        image: pecax/sbml4j:1.2.2
         container_name: sbml4j
         volumes:
             - sbml4j_service_vol:/logs
@@ -106,7 +100,7 @@ services:
             - SPRING_DATA_NEO4j_URI=bolt://sbml4jdb:7687
             - SERVER_SERVLET_CONTEXTPATH=/sbml4j
             - SERVER_PORT=8080
-            - OVERVIEWNETWORK_DEFAULT_BASE-NETWORK-NAME=PeCaX-Base
+            - OVERVIEWNETWORK_DEFAULT_BASE-NETWORK-NAME=Overview_Base
             - OVERVIEWNETWORK_DEFAULT_MINSIZE=0
             - OVERVIEWNETWORK_DEFAULT_MAXSIZE=2
             - OVERVIEWNETWORK_DEFAULT_TERMINATEAT=Drugtarget


### PR DESCRIPTION
This now uses the new (security patched) version of SBML4j.
A new database is needed as there have been major changes in the middleware of SBML4j.